### PR TITLE
Add .speedTrap type to sequencer

### DIFF
--- a/Dreamline/Dreamline/Board.swift
+++ b/Dreamline/Dreamline/Board.swift
@@ -163,9 +163,10 @@ class DefaultBoard: Board {
         var distance = state.distanceSinceLastTrigger + step
         if distance > config.boardDistanceBetweenTriggers {
             distance = 0.0 // @HACK: this is used later in this function, very fragile
-            updatedTotalTriggerCount += 1
+            
             let triggers = sequencer.getNextTrigger(config: config)
             for triggerType in triggers {
+                updatedTotalTriggerCount += 1
                 let newTrigger = Trigger(id: updatedTotalTriggerCount,
                                          position: layout.spawnPosition,
                                          status: .idle,

--- a/Dreamline/Dreamline/Sequencer.swift
+++ b/Dreamline/Dreamline/Sequencer.swift
@@ -110,6 +110,8 @@ class AuthoredSequencer: Sequencer {
             queue.append(self.newGapPattern(count: 3))
             queue.append(self.newPacerPattern())
             queue.append(self.newGapPattern(count: 3))
+            queue.append(self.newSpeedTrapPattern())
+            queue.append(self.newGapPattern(count: 3))
         }
         
         // otherwise, pull from queue
@@ -144,6 +146,14 @@ class AuthoredSequencer: Sequencer {
         
         let triggers = [leftBoost, rightBoost, leftBoost] // @TODO: Chirality support
         return Group(pattern: .boost, triggers: triggers, index: 0)
+    }
+    
+    private func newSpeedTrapPattern() -> Group {
+        let barrier: TriggerType = .barrier(Barrier(gates: [.closed, .open, .closed]))
+        let modifier: TriggerType = .modifier(ModifierRow(modifiers: [.none, .speedUp, .none]))
+        
+        let triggers = [[barrier, modifier]]
+        return Group(pattern: .speedTrap, triggers: triggers, index: 0)
     }
     
     private func newTunnelPattern() -> Group {


### PR DESCRIPTION
Speed trap is a speed up modifier in the middle of a single-gate barrier.
Also fixed a bug where overlapping triggers weren't being added correctly.